### PR TITLE
Fixed missing / in module.json

### DIFF
--- a/module.json
+++ b/module.json
@@ -26,7 +26,7 @@
     "compatibleCoreVersion": "0.8.5",
     "url": "https://github.com/theripper93/Smart-Target",
     "manifest": "https://github.com/theripper93/Smart-Target/releases/latest/download/module.json",
-    "download": "https://github.com/theripper93/Smart-Target/releaseslatest/download/module.zip",
+    "download": "https://github.com/theripper93/Smart-Target/releases/latest/download/module.zip",
     "license": "",
 	"readme": "https://raw.githubusercontent.com/theripper93/Smart-Target/main/README.md",
 	"changelog": "https://raw.githubusercontent.com/theripper93/Smart-Target/master/changelog.md",


### PR DESCRIPTION
Added a missing / in the module.json which prevented the module from being installed and ended in a 404 error.