### PR TITLE
Bug fix for "As GM target indicator is avatar instead of selected token"

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
-## [0.2] 2021-05-23
+## 0.5.2
+
+- Bug fix  [Bug As GM target indicator is avatar instead of selected token](https://github.com/theripper93/Smart-Target/issues/13)
+
+
+## 0.2 2021-05-23
 
 - Initial version and integration of some feature from [target-enhancements](https://github.com/eadorin/target-enhancements)

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "name": "smarttarget",
     "title": "Smart Target",
     "description": "Enhancements for the targeting feature",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "authors": [
         {
             "name": "theripper93",


### PR DESCRIPTION
This pull request shoul be a fix for the [Bug As GM target indicator is avatar instead of selected token](https://github.com/theripper93/Smart-Target/issues/13) issue.

There are two cons though:

1) to pass the information about the token image I had to use an additional mechanism in this case the flags (perhaps a solution with sockets could be more efficient in the future)
2) To maintain backward compatibility with 0.7 I used the deprecated method of setting flags on the 'data' object  instead on the document, this may also need to be fixed in the future, but I don't think 0.9.0 will arrive anytime soon, so several warning logs will appear on the console of the type:

`foundry.js:19277 You are calling PlaceableObject#unsetFlag which has been deprecated in favor of Document#unsetFlag. Support will be removed in 0.9.0`

Make some test seem to work.

If, on the other hand, you have suggestions or tricks that you want me to integrate let me know.
Greeting.